### PR TITLE
Add mention of other eshops in welcome message

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -126,6 +126,8 @@ DM me with Alza links and I'll order them. Like this:
 Do you want to order 3 Cool Coolers and 2 Cool Smartphones? Just tell me so:
 > 3 https://www.alza.sk/cool-cooler 2 https://www.alza.sk/cool-smartphone
 
+Although I work the best with Alza, I’m also able to get you items from other eshops, if need be. Just paste the link and I’ll handle it.
+
 Happy shopping!
 
 PS: Feel free to contribute at https://github.com/vacuumlabs/eshop-api`})


### PR DESCRIPTION
I just found out that it is possible (and prefered to) send orders from eshops-that-are-not-Alza through Alzabot!

In my opinion it should be at least mentioned in the Alzabot's introduction message (and probably on the staff handbook as well).