### PR TITLE
Verified price should be bool when storing order in Airtable

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -708,7 +708,7 @@ async function storeOrder(order, items) {
       'Count': item.count,
       ...(item.price ? {Price: item.price} : null),
       'Order': [airtableOrder.getId()],
-      'Verified Price': !item.withoutLogin && item.price,
+      'Verified Price': !item.withoutLogin && Boolean(item.price),
     })
   }
 


### PR DESCRIPTION
This would cause the app to crash when deployed in test env. I can't really explain why it doesn't crash in production - different lib versions maybe?