### PR TITLE
Migrate actions handling to use @slack/bolt

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -13,6 +13,7 @@ const logger = winston.createLogger({
 
 export default logger
 
+// TODO: take username instead
 export function logError(variant, e, msg, userId, data) {
   logger.error(`logError. error: ${e} | msg: ${msg} | userId: ${userId} | error.response: ${JSON.stringify(e.response)} | data: ${JSON.stringify(data)}`)
 

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -57,6 +57,10 @@ export class Slack {
     const {user_id: botUserId} = await this.apiCall('auth.test')
     this.botUserId = botUserId
 
+    /* old Milan's code for upgrading all messages to a new message format
+        - outdated, but potentially useful
+        - should be ran single time, but probably wouldn't matter if by any chance it is ran multiple times
+    */
     // const channels = [
     //   c.ordersChannel,
     //   c.ordersChannelSkBa,
@@ -119,6 +123,7 @@ export class Slack {
 
     // console.log('Upgrade complete')
 
+    // TODO: inline handleMessage
     this.boltApp.event('message', ({event}) => this.handleMessage(event))
 
     this.boltApp.event('team_join', ({event}) => this.greetNewUser(event.user.id))
@@ -293,7 +298,6 @@ export class Slack {
           }
         }
 
-        //
         if (event.type === 'message') {
           const newId = this.nextUUID()
           this.pendingActions[newId] = stream
@@ -309,8 +313,6 @@ export class Slack {
             await this.showError(user, event.original_message.ts, 'Something went wrong, please try again.')
           }
         }
-
-        // console.log(';;', event && event.type)
       }
 
       destroyOrder(order)


### PR DESCRIPTION
finally got rid of the first-level yacol stream and used @slack/bolt's official approach - give us a more clear code and allows us to use e.g. `respond` function instead of cumbersomely calling the chat API ourselves