### PR TITLE
Add missing spinoff migration for vacuumlabs

### DIFF
--- a/src/knex/migrations/20220125112109_add_spinoff_column_for_vacuumlabs.js
+++ b/src/knex/migrations/20220125112109_add_spinoff_column_for_vacuumlabs.js
@@ -1,0 +1,11 @@
+exports.up = async (knex) => {
+  await knex.schema.table('order', (table) => {
+    table.string('spinoff')
+  })
+}
+
+exports.down = async (knex) => {
+  await knex.schema.table('order', (table) => {
+    table.dropColumn('spinoff')
+  })
+}


### PR DESCRIPTION
we allowed the spinoff question for both test and vacuumlabs variants, but migrated just the test db tables