### PR TITLE
refactored actions and messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "request": "^2.88.0",
     "request-promise": "^4.2.4",
     "transenv": "^1.0.3",
-    "winston": "^3.2.1",
-    "yacol": "^0.8.0"
+    "winston": "^3.2.1"
   },
   "resolutions": {
     "deep-extend": "0.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import express from 'express'
-import {expressHelpers, run} from 'yacol'
 
 import c from './config'
 import {Slack} from './slack/slack'
@@ -7,8 +6,6 @@ import {alzaCode} from './alza'
 import logger from './logger'
 
 const app = express()
-
-const {register, runApp} = expressHelpers
 
 const endpoints = {
   alzaCode: '/alzacode',
@@ -26,10 +23,7 @@ const endpoints = {
   },
 }
 
-register(app, 'get', endpoints.alzaCode, alzaCode)
-
 ;(async function() {
-  run(runApp)
 
   app.listen(c.port, () =>
     logger.info(`App started on localhost:${c.port}.`)

--- a/src/slack/constants.js
+++ b/src/slack/constants.js
@@ -4,24 +4,27 @@ import * as wincentConstants from './wincent/constants'
 
 const REASON = 'reason'
 const MANAGER = 'manager'
+const NAME = 'name'
+const QUESTION = 'question'
+const BUTTON = 'button'
 
 const REASON_WITH_ADDRESS_QUESTION = {
-  [REASON]: ':question: Why do you need these items? Reply by sending a message. And don\'t forget to tell us your address!',
+  [NAME]: REASON, [QUESTION]: ':question: Why do you need these items? Reply by sending a message. And don\'t forget to tell us your address!',
 }
 
 const REASON_DEFAULT_QUESTION = {
-  [REASON]: ':question: Why do you need these items? Reply by sending a message.',
+  [NAME]: REASON, [QUESTION]: ':question: Why do you need these items? Reply by sending a message.',
 }
 
 const REASON_NOTE_QUESTION = {
-  [REASON]: ':pencil: Add a note by sending a message. And don\'t forget to tell us your address!',
+  [NAME]: REASON, [QUESTION]: ':pencil: Add a note by sending a message. And don\'t forget to tell us your address!',
 }
 
 const REASON_COMMENT_QUESTION = {
-  [REASON]: ':pencil: Send your comment in a message.',
+  [NAME]: REASON, [QUESTION]: ':pencil: Send your comment in a message.', [BUTTON]: vlConstants.NOTE_NO_ACTION,
 }
 
-const MANAGER_QUESTION = {[MANAGER]: ':question: Name of your manager (needed for approval for items above 100 EUR - write N/A otherwise):'}
+const MANAGER_QUESTION = {[NAME]: MANAGER, [QUESTION]: ':question: Name of your manager (needed for approval for items above 100 EUR - write N/A otherwise):'}
 
 export const COMPANY = 'company'
 export const PERSONAL = 'personal'
@@ -45,24 +48,24 @@ const NOTIFICATION = {
 
 const DEFAULT_MESSAGES = {
   home: {
-    company: {
-      ...REASON_WITH_ADDRESS_QUESTION,
-      ...MANAGER_QUESTION,
-    },
-    personal: REASON_NOTE_QUESTION,
+    company: [
+      REASON_WITH_ADDRESS_QUESTION,
+      MANAGER_QUESTION,
+    ],
+    personal: [REASON_NOTE_QUESTION],
   },
   office: {
-    company: {
-      ...REASON_DEFAULT_QUESTION,
-      ...MANAGER_QUESTION,
-    },
+    company: [
+      REASON_DEFAULT_QUESTION,
+      MANAGER_QUESTION,
+    ],
     personal: {
-      note: REASON_COMMENT_QUESTION,
+      note: [REASON_COMMENT_QUESTION],
     },
   },
-
   notification: NOTIFICATION,
 }
+
 
 const WINCENT_MESSAGES = {
   home: {
@@ -109,8 +112,6 @@ export const CITIES_OPTIONS_TO_CITIES = {
 export const OFFICES = vlConstants.OFFICES
 
 export const HOME_VALUE = vlConstants.HOME_VALUE
-
-export const HOME_TO_OFFICE = vlConstants.HOME_TO_OFFICE
 
 export const CANCEL_ORDER_ACTION = vlConstants.CANCEL_ORDER_ACTION
 

--- a/src/slack/constants.js
+++ b/src/slack/constants.js
@@ -4,9 +4,9 @@ import * as wincentConstants from './wincent/constants'
 
 const REASON = 'reason'
 const MANAGER = 'manager'
-const NAME = 'name'
-const QUESTION = 'question'
 const BUTTON = 'button'
+const QUESTION = 'question'
+export const NAME = 'name'
 
 const REASON_WITH_ADDRESS_QUESTION = {
   [NAME]: REASON, [QUESTION]: ':question: Why do you need these items? Reply by sending a message. And don\'t forget to tell us your address!',

--- a/src/slack/constants.js
+++ b/src/slack/constants.js
@@ -69,13 +69,13 @@ const DEFAULT_MESSAGES = {
 
 const WINCENT_MESSAGES = {
   home: {
-    company: REASON_WITH_ADDRESS_QUESTION,
-    personal: REASON_NOTE_QUESTION,
+    company: [REASON_WITH_ADDRESS_QUESTION],
+    personal: [REASON_NOTE_QUESTION],
   },
   office: {
-    company: REASON_DEFAULT_QUESTION,
+    company: [REASON_DEFAULT_QUESTION],
     personal: {
-      note: REASON_COMMENT_QUESTION,
+      note: [REASON_COMMENT_QUESTION],
     },
   },
 

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -18,7 +18,6 @@ export class Slack {
     this.config = c[variant]
     this.orders = {}
     this.streams = {}
-    this.pendingActions = {}
 
     // inspired by: https://github.com/slackapi/bolt-js/issues/212
     this.boltReceiver = new ExpressReceiver({signingSecret: this.config.slack.signingSecret, endpoints: '/'})

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -1,6 +1,5 @@
 import c from '../config'
 import _knex from 'knex'
-import {createChannel} from 'yacol'
 import moment from 'moment-timezone'
 import {getInfo, getLangByLink} from '../alza'
 import {format} from '../currency'
@@ -17,9 +16,9 @@ export class Slack {
   constructor(variant) {
     this.variant = variant
     this.config = c[variant]
+    this.orders = {}
     this.streams = {}
     this.pendingActions = {}
-    this.actionsCount = 0
 
     // inspired by: https://github.com/slackapi/bolt-js/issues/212
     this.boltReceiver = new ExpressReceiver({signingSecret: this.config.slack.signingSecret, endpoints: '/'})
@@ -116,7 +115,7 @@ export class Slack {
 
         await ack()
 
-        const callback_id = body.callback_id
+        const {callback_id, user: {id: userId}} = body
 
         logger.info(`action callback_id: ${callback_id}, username: ${body.user.name}`)
 
@@ -126,7 +125,7 @@ export class Slack {
             await this.handleOrderAction(body)
           } catch (err) {
             await say(':exclamation: Something went wrong.')
-            await logError(this.boltApp, this.variant, err, 'Admin action error', body.user.id, {
+            await logError(this.boltApp, this.variant, err, 'Admin action error', userId, {
               action,
               callback_id,
             })
@@ -135,13 +134,7 @@ export class Slack {
         }
 
         // user action
-        // TODO: handle user's action right here, don't use stream
-        const actionStream = this.pendingActions[callback_id]
-        if (actionStream) {
-          actionStream.put({...body, type: 'action'})
-        } else {
-          await respond(':exclamation: The order has timed out. Create a new order please.')
-        }
+        this.handleUserAction(action, userId)
       } catch (err) {
         await respond(':exclamation: Something went wrong.')
         await logError(this.boltApp, this.variant, err, 'General action error', body.user.id, {
@@ -160,10 +153,6 @@ export class Slack {
     this.boltApp.error(errorHandler)
   }
 
-  nextUUID() {
-    return (`${Date.now()}#${this.actionsCount++}`)
-  }
-
   amIMentioned(event) {
     // ignore messages from the bot
     if (event.user === this.botUserId) return false
@@ -172,14 +161,6 @@ export class Slack {
     // the bot is mentioned
     if (event.text.match(`<@${this.botUserId}>`)) return true
     return false
-  }
-
-  streamForUser(userId) {
-    if (this.streams[userId] == null) {
-      this.streams[userId] = createChannel()
-      this.listenUser(this.streams[userId], userId)
-    }
-    return this.streams[userId]
   }
 
   async announceToAll(message) {
@@ -220,7 +201,7 @@ export class Slack {
     if (event.subtype) return
 
     if (this.amIMentioned(event)) {
-      this.streamForUser(event.user).put(event)
+      this.handleUserMessage(event)
       return
     }
 
@@ -240,10 +221,12 @@ export class Slack {
       logger.error(`Failed to show an error to user: ${err}`)
     }
   }
+  async handleUserMessage(event) {
+    const {user: userId} = event
 
-  async listenUser(stream, userId) {
-    const newOrder = () => ({
-      id: null,
+    const newOrder = () => ({ // Messages
+      id: userId,
+      state: 'new',
       items: new Map(),
       totalPrice: 0,
       country: null,
@@ -254,65 +237,64 @@ export class Slack {
       isHome: null,
     })
 
-    const destroyOrder = (order) => {
-      if (order.id) delete this.pendingActions[order.id]
+    const destroyOrder = (userId) => {
+      delete this.orders[userId]
     }
 
-    for (;;) {
-      let order = newOrder()
+    this.orders[userId] = this.orders[userId] || newOrder()
+    let order = this.orders[userId]
 
-      for (;;) {
-        const event = await stream.take()
-
-        if (event.type === 'action') {
-          let finished
-
-          try {
-            finished = await this.handleUserAction(
-              stream,
-              order,
-              event.actions[0],
-              event.user,
-            )
-          } catch (err) {
-            finished = true
-
-            await logError(this.boltApp, this.variant, err, 'User action error', event.user.id, {
-              action: event.actions[0].name,
-              value: event.actions[0].value,
-              order: logOrder(order),
-            })
-            try {
-              await this.showError(order.orderConfirmation.channel, event.original_message.ts, 'Something went wrong, please try again.')
-            } catch (err) {
-              logger.error(`couldn't show error to the user. error: ${err}`)
-            }
-          }
-
-          if (finished) {
-            break
-          }
-        }
-
-        if (event.type === 'message') {
-          const newId = this.nextUUID()
-          this.pendingActions[newId] = stream
-          order.id = newId
-
-          try {
-            order = await this.updateOrder(order, event, userId)
-          } catch (err) {
-            await logError(this.boltApp, this.variant, err, 'User order error', userId, {
-              msg: event.text,
-              order: logOrder(order),
-            })
-            await this.showError(userId, null, 'Something went wrong, please try again.') // Pass null instead of event.original_message.ts, as event with type === 'message' doesn't contain original_message
-          }
-        }
+    if (order.messages === undefined) { // Initial message for entering item links
+      try {
+        order = await this.updateOrder(order, event, userId)
+      } catch (err) {
+        await logError(this.boltApp, this.variant, err, 'User order error', userId, {
+          msg: event.text,
+          order: logOrder(order),
+        })
+        await this.showError(userId, null, 'Something went wrong, please try again.') // Pass null instead of event.original_message.ts, as event with type === 'message' doesn't contain original_message
       }
+    } else {
+      const {name} = this.orders[userId].messages.shift()
+      order[name] = event.text
 
-      destroyOrder(order)
+      if (order.messages.length === 0) { // user actions finished
+        const dbId = await this.storeOrder(
+          {
+            user: userId,
+            ts: order.orderConfirmation.ts,
+            isCompany: order.isCompany,
+            office: order.office,
+            reason: order.reason,
+            isUrgent: order.isUrgent,
+            isHome: order.isHome,
+            ...this.variant === 'wincent' ? {} : {spinoff: order.spinoff, manager: order.manager},
+          },
+          order.items,
+        )
+        await this.notifyOfficeManager(order, dbId, userId, order.isCompany)
+        await this.updateMessage(order, {
+          pretext: order.isCompany ? ':office: Company order finished:' : ':woman: Personal order finished:',
+          color: 'good',
+          actions: [],
+          fields: this.getOrderFields(order),
+        })
+        try {
+          await this.boltApp.client.chat.postMessage({
+            channel: userId,
+            as_user: true,
+            text: order.isCompany ? ':office: Company order finished :point_up:' : ':woman: Personal order finished :point_up:',
+          })
+        } catch (err) {
+          logger.error(`Failed to post 'order finished' message to user '${userId}': ${err}`)
+        }
+        destroyOrder(userId)
+      } else {
+        this.updateQuestion(userId)
+      }
     }
+
+    this.orders[userId] = order
   }
 
   async changeStatus({
@@ -604,159 +586,98 @@ export class Slack {
     }
   }
 
-  async handleUserAction(stream, order, action, user) {
-    const {name: actionName, value: actionValue} = action
-    logger.info(`handling user action - name: ${actionName}, value: ${actionValue}, user: ${JSON.stringify(user)}, order: ${JSON.stringify(order)}`)
+  async updateQuestion(userId) {
+    const order = this.orders[userId]
+    const userMessage = order.messages[0]
 
+    if (userMessage) {
+      const {question, button: additionalButton} = userMessage
+      await this.updateMessage(order, {
+        actions: [additionalButton, CANCEL_ORDER_ACTION].filter(Boolean),
+        fields: this.getOrderFields(order),
+      })
+
+      try {
+        await this.boltApp.client.chat.postMessage({
+          channel: userId,
+          as_user: true,
+          text: question,
+        })
+      } catch (err) {
+        logger.error(`Failed to post a message '${question}' to user '${userId}': ${err}`)
+      }
+    }
+  }
+
+  async updateMessage(order, attachmentUpdate) {
     const {channel, ts, message: {attachments: [attachment]}} = order.orderConfirmation
+    try {
+      await this.boltApp.client.chat.update({ts, channel, text: ' ', attachments: [{...attachment, ...attachmentUpdate}]})
+    } catch (err) {
+      logger.error(`Failed to update a chat on '${channel}': ${err}`)
+    }
+  }
+
+  async handleUserAction(action, userId) {
+    const order = this.orders[userId]
+    const {name: actionName, value: actionValue} = action
+    logger.info(`handling user action - name: ${actionName}, value: ${actionValue}, user: ${JSON.stringify(userId)}, order: ${JSON.stringify(order)}`)
 
     const MESSAGES = VARIANT_MESSAGES[this.variant]
 
-    const updateMessage = async (attachmentUpdate) => {
-      try {
-        await this.boltApp.client.chat.update({ts, channel, text: ' ', attachments: [{...attachment, ...attachmentUpdate}]})
-      } catch (err) {
-        logger.error(`Failed to update a chat on '${channel}': ${err}`)
-      }
-    }
-
     const cancelOrder = async () => {
-      await updateMessage({
+      await this.updateMessage(order, {
         pretext: ':no_entry_sign: Order canceled:',
         color: 'danger',
         actions: [],
       })
     }
 
-    const submitOrder = async (commentMsgObj, forceComment) => {
-      let completeNewMsg = false
-
-      if (commentMsgObj) {
-        completeNewMsg = true
-
-        for (const [key, msg] of Object.entries(commentMsgObj)) {
-          await updateMessage({
-            actions: [forceComment ? null : NOTE_NO_ACTION, CANCEL_ORDER_ACTION].filter(Boolean),
-            fields: this.getOrderFields(order),
-          })
-
-          try {
-            await this.boltApp.client.chat.postMessage({
-              channel: user.id,
-              as_user: true,
-              text: msg,
-            })
-          } catch (err) {
-            logger.error(`Failed to post a message '${msg}' to user '${user.id}': ${err}`)
-          }
-
-          const event = await stream.take()
-
-          if (event.type === 'message') {
-            order[key] = event.text
-            completeNewMsg = true
-          } else if (event.type === 'action' && event.actions[0].name === 'cancel') {
-            await cancelOrder()
-            try {
-              await this.boltApp.client.chat.postMessage({
-                channel: user.id,
-                as_user: true,
-                text: ':no_entry_sign: Canceling :point_up:',
-              })
-            } catch (err) {
-              logger.error(`Failed to post canceling message on channel '${user.id}': ${err}`)
-            }
-            return
-          }
-        }
-      }
-
-      const dbId = await this.storeOrder(
-        {
-          user,
-          ts,
-          isCompany: order.isCompany,
-          office: order.office,
-          reason: order.reason,
-          isUrgent: order.isUrgent,
-          isHome: order.isHome,
-          ...this.variant === 'wincent' ? {} : {spinoff: order.spinoff, manager: order.manager},
-        },
-        order.items,
-      )
-      await this.notifyOfficeManager(order, dbId, user.id, order.isCompany)
-      await updateMessage({
-        pretext: order.isCompany ? ':office: Company order finished:' : ':woman: Personal order finished:',
-        color: 'good',
-        actions: [],
-        fields: this.getOrderFields(order),
-      })
-      if (completeNewMsg) {
-        try {
-          await this.boltApp.client.chat.postMessage({
-            channel: user.id,
-            as_user: true,
-            text: order.isCompany ? ':office: Company order finished :point_up:' : ':woman: Personal order finished :point_up:',
-          })
-        } catch (err) {
-          logger.error(`Failed to post 'order finished' message to user '${user.id}': ${err}`)
-        }
-      }
-    }
-
     if (actionName === 'cancel') {
       await cancelOrder()
-      return true
     }
 
     if (actionName === 'country') {
 
       order.country = actionValue
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: DELIVERY_PLACE_ACTIONS,
         fields: [
           ...this.getOrderFields(order),
           {title: 'Where do you want to pickup the order?'},
         ],
       })
-
-      return false
     }
 
     // office/home
     if (actionName === 'delivery') {
       order.isHome = actionValue === HOME_VALUE
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: ORDER_OFFICE_ACTIONS[order.country],
         fields: [
           ...this.getOrderFields(order),
           {title: 'Select the office you belong to.'},
         ],
       })
-
-      return false
     }
 
     // office
     if (actionName === 'office') {
       order.office = actionValue
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: ORDER_TYPE_ACTIONS,
         fields: this.getOrderFields(order),
       })
 
-      return false
     }
 
     // ?-personal
     if (actionName === 'personal') {
       order.isCompany = false
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: ORDER_URGENT_ACTIONS,
         fields: [...this.getOrderFields(order), {title: 'How urgent is your order?'}],
       })
-
-      return false
     }
 
     // ?-personal-urgent
@@ -765,22 +686,21 @@ export class Slack {
 
       // home-personal-urgent
       if (order.isHome) {
-        await submitOrder(MESSAGES.home.personal, true)
-        return true
+        order.messages = MESSAGES.home.personal
       }
 
       // office-personal-urgent
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: ORDER_NOTE_ACTIONS,
         fields: [...this.getOrderFields(order), {title: ':pencil: Do you want to add a note to the order?'}],
       })
-      return false
     }
 
     // office-personal-?-note
     if (actionName === 'note') {
-      await submitOrder(actionValue === 'note-yes' ? MESSAGES.office.personal.note : null)
-      return true
+      if (actionValue === 'note-yes') {
+        order.messages = MESSAGES.office.personal.note
+      }
     }
 
     // ?-company
@@ -789,17 +709,14 @@ export class Slack {
 
       // for wincent, don't go into spinoff selection
       if (this.variant === 'wincent') {
-        await submitOrder(order.isHome ? MESSAGES.home.company : MESSAGES.office.company, true)
-        return true
+        order.messages = order.isHome ? MESSAGES.home.company : MESSAGES.office.company
       }
 
       // spinoff selection for vacuumlabs (and test)
-      await updateMessage({
+      await this.updateMessage(order, {
         actions: ORDER_SPINOFF_ACTIONS,
         fields: [...this.getOrderFields(order), {title: 'Select your spinoff:'}],
       })
-
-      return false
     }
 
     // ?-company-spinoff
@@ -807,11 +724,14 @@ export class Slack {
     if (actionName === 'spinoff') {
       order.spinoff = action.selected_options[0].value
 
-      await submitOrder(order.isHome ? MESSAGES.home.company : MESSAGES.office.company, true)
-      return true
+      order.messages = order.isHome ? MESSAGES.home.company : MESSAGES.office.company
     }
 
-    return false
+    this.orders[userId] = order // update order
+
+    if (order.messages !== undefined && order.messages.length > 0) { // If order actions finished, update question
+      this.updateQuestion(userId)
+    }
   }
 
   async notifyOfficeManager(order, dbId, user, isCompany) {
@@ -921,7 +841,7 @@ export class Slack {
       try {
         await this.boltApp.client.chat.delete({channel, ts})
       } catch (err) {
-        logger.error(`Failed to delete message on channel '${channel}': ${err}`)
+        logger.error(`Failed to delete message on channel '${channel} ci': ${err}`)
       }
     }
 
@@ -969,6 +889,7 @@ export class Slack {
         as_user: true,
         text: ' ',
       })
+
       return {...order, orderConfirmation}
     } catch (err) {
       logger.error(`Failed to post a message to user '${user}': ${err}`)
@@ -1019,7 +940,7 @@ export class Slack {
   async storeOrder(order, items) {
     const id = await knex.transaction(async (trx) => {
       logger.info(`storing order to the db: ${JSON.stringify(order)}`)
-      const orderInsertResult = await trx.insert({...order, user: order.user.id}, ['id']).into(this.config.dbTables.order)
+      const orderInsertResult = await trx.insert({...order}, ['id']).into(this.config.dbTables.order)
 
       order.id = orderInsertResult[0].id
 

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -17,7 +17,6 @@ export class Slack {
     this.variant = variant
     this.config = c[variant]
     this.orders = {}
-    this.streams = {}
 
     // inspired by: https://github.com/slackapi/bolt-js/issues/212
     this.boltReceiver = new ExpressReceiver({signingSecret: this.config.slack.signingSecret, endpoints: '/'})

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -6,7 +6,7 @@ import {format} from '../currency'
 import logger, {logError, logOrder} from '../logger'
 import {storeOrder as storeOrderToSheets} from '../sheets/storeOrder'
 import {updateStatus as updateStatusInSheets} from '../sheets/updateStatus'
-import {CANCEL_ORDER_ACTION, CITIES_OPTIONS_TO_CITIES, HOME_VALUE, NEW_USER_GREETING, NOTE_NO_ACTION, OFFICES, ORDER_NOTE_ACTIONS, ORDER_OFFICE_ACTIONS, ORDER_SPINOFF_ACTIONS, ORDER_TYPE_ACTIONS, ORDER_URGENT_ACTIONS, SLACK_URL, COMPANY, PERSONAL, OFFICE, HOME, DELIVERY_PLACE_ACTIONS, MESSAGES as VARIANT_MESSAGES} from './constants'
+import {CANCEL_ORDER_ACTION, CITIES_OPTIONS_TO_CITIES, HOME_VALUE, NEW_USER_GREETING, OFFICES, ORDER_NOTE_ACTIONS, ORDER_OFFICE_ACTIONS, ORDER_SPINOFF_ACTIONS, ORDER_TYPE_ACTIONS, ORDER_URGENT_ACTIONS, SLACK_URL, COMPANY, PERSONAL, OFFICE, HOME, DELIVERY_PLACE_ACTIONS, MESSAGES as VARIANT_MESSAGES} from './constants'
 import {getAdminSections, getArchiveSection, getNewOrderAdminSections, getUserActions} from './actions'
 import {App, ExpressReceiver} from '@slack/bolt'
 
@@ -132,7 +132,11 @@ export class Slack {
         }
 
         // user action
-        this.handleUserAction(action, userId)
+        if (this.orders[userId]) {
+          this.handleUserAction(action, userId)
+        } else {
+          await respond(':exclamation: The order has timed out. Create a new order please.')
+        }
       } catch (err) {
         await respond(':exclamation: Something went wrong.')
         await logError(this.boltApp, this.variant, err, 'General action error', body.user.id, {

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -637,6 +637,8 @@ export class Slack {
 
     if (actionName === 'cancel') {
       await cancelOrder()
+      delete this.orders[userId] // remove order from memory
+      return
     }
 
     if (actionName === 'country') {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,4 @@
-import {run} from 'yacol'
 import {getInfo} from './src/alza'
-import {connect, listen, apiCall} from './src/slack'
-import c from './src/config'
 
 (async function() {
   const products = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3590,11 +3590,6 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-on-headers@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
-  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4843,11 +4838,6 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
-transducers-js@^0.4.174:
-  version "0.4.174"
-  resolved "https://registry.yarnpkg.com/transducers-js/-/transducers-js-0.4.174.tgz#d5862c10eff4be3d3322abf6bb742e30f1bb6fc4"
-  integrity sha1-1YYsEO/0vj0zIqv2u3QuMPG7b8Q=
-
 transenv@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/transenv/-/transenv-1.0.3.tgz#64b5587ac395956c6e5bf0ead52cb11e107515be"
@@ -5090,14 +5080,6 @@ xtend@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
-
-yacol@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/yacol/-/yacol-0.8.0.tgz#c19d5559cd8be970ca0b18d9efb85b60a1b280ed"
-  integrity sha512-BaNpqEROp+WhBZ48BBclFu2Fooyaeq2zxCiOOErxL9duUqHT7luWVNYzfEJI3uWZHL3+eDl4cSTw9jM/aGB3tg==
-  dependencies:
-    on-headers "^1.0.1"
-    transducers-js "^0.4.174"
 
 yallist@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
- removed `yacol-createChanne`l from the app.
- After user-actions finished, `message_list` will be set to order.
- User can add items links during actions, till the last `note-reason-manager` steps.

Note:
Maybe we can improve action and message handling by one/common `TRIE` data structure containing ordered actions/messages.