### PR TITLE
HAW-23 added action rank checking

### DIFF
--- a/src/slack/constants.js
+++ b/src/slack/constants.js
@@ -132,22 +132,3 @@ export const ORDER_NOTE_ACTIONS = vlConstants.ORDER_NOTE_ACTIONS
 export const ORDER_COMPANY_ACTIONS = vlConstants.ORDER_COMPANY_ACTIONS
 
 export const DELIVERY_PLACE_ACTIONS = vlConstants.DELIVERY_PLACE_ACTIONS
-
-export const ACTION_RANKS = {
-  new: 0,
-  country: 1,
-  delivery: 2,
-  office: 3,
-  type: 4,
-  is_personal: 4,
-  is_company: 4,
-  urgent: 5,
-  company: 5,
-  note: 6,
-  note_yes: 7,
-  without_note: 8,
-  reason: 8,
-  manager: 9,
-  cancel: 10,
-  finish: 11,
-}

--- a/src/slack/constants.js
+++ b/src/slack/constants.js
@@ -8,6 +8,8 @@ const BUTTON = 'button'
 const QUESTION = 'question'
 export const NAME = 'name'
 
+export const WITHOUT_NOTE_ACTION = {name: 'without_note', text: 'Continue without note', type: 'button', value: 'without_note'}
+
 export const INVALID_LINK_ERROR = ':exclamation: The links you sent me are invalid.\nIf you want to add a comment, please start by sending the links first and you will be asked for a note later in the process.'
 
 const REASON_WITH_ADDRESS_QUESTION = {
@@ -23,7 +25,7 @@ const REASON_NOTE_QUESTION = {
 }
 
 const REASON_COMMENT_QUESTION = {
-  [NAME]: REASON, [QUESTION]: ':pencil: Send your comment in a message.', [BUTTON]: vlConstants.NOTE_NO_ACTION,
+  [NAME]: REASON, [QUESTION]: ':pencil: Send your comment in a message.', [BUTTON]: WITHOUT_NOTE_ACTION,
 }
 
 const MANAGER_QUESTION = {[NAME]: MANAGER, [QUESTION]: ':question: Name of your manager (needed for approval for items above 100 EUR - write N/A otherwise):'}
@@ -130,3 +132,22 @@ export const ORDER_NOTE_ACTIONS = vlConstants.ORDER_NOTE_ACTIONS
 export const ORDER_COMPANY_ACTIONS = vlConstants.ORDER_COMPANY_ACTIONS
 
 export const DELIVERY_PLACE_ACTIONS = vlConstants.DELIVERY_PLACE_ACTIONS
+
+export const ACTION_RANKS = {
+  new: 0,
+  country: 1,
+  delivery: 2,
+  office: 3,
+  type: 4,
+  is_personal: 4,
+  is_company: 4,
+  urgent: 5,
+  company: 5,
+  note: 6,
+  note_yes: 7,
+  without_note: 8,
+  reason: 8,
+  manager: 9,
+  cancel: 10,
+  finish: 11,
+}

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -6,7 +6,7 @@ import {format} from '../currency'
 import logger, {logError, logOrder} from '../logger'
 import {storeOrder as storeOrderToSheets} from '../sheets/storeOrder'
 import {updateStatus as updateStatusInSheets} from '../sheets/updateStatus'
-import {CANCEL_ORDER_ACTION, CITIES_OPTIONS_TO_CITIES, HOME_VALUE, NEW_USER_GREETING, OFFICES, OFFICE, SLACK_URL, COMPANY, PERSONAL, HOME, NAME, MESSAGES as VARIANT_MESSAGES, INVALID_LINK_ERROR, ACTION_RANKS} from './constants'
+import {CANCEL_ORDER_ACTION, CITIES_OPTIONS_TO_CITIES, HOME_VALUE, NEW_USER_GREETING, OFFICES, OFFICE, SLACK_URL, COMPANY, PERSONAL, HOME, NAME, MESSAGES as VARIANT_MESSAGES, INVALID_LINK_ERROR} from './constants'
 import {getAdminSections, getArchiveSection, getNewOrderAdminSections, getUserActions} from './actions'
 import {App, ExpressReceiver} from '@slack/bolt'
 
@@ -729,7 +729,7 @@ export class Slack {
     // office-is_personal-?-note
     if (actionName === 'note') {
       if (actionValue === 'note_yes') {
-        order.messages = MESSAGES.office.personal.note
+        order.messages = [...MESSAGES.office.personal.note]
       } else {
         this.submitOrder(userId)
         return

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -292,7 +292,7 @@ export class Slack {
         attachments: [orderAttachment],
       })
     } catch (err) {
-      logger.error(`Failed to an order finished message to user '${userId}': ${err}`)
+      logger.error(`Failed to post an order finished message to user '${userId}': ${err}`)
     }
 
     delete this.orders[userId] // remove order from memory

--- a/src/slack/test/constants.js
+++ b/src/slack/test/constants.js
@@ -117,21 +117,21 @@ export const ORDER_COMPANY_ACTIONS = [
 ]
 
 export const ORDER_TYPE_ACTIONS = [
-  {name: 'is_personal', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
-  {name: 'is_company', text: 'Make Company Order', type: 'button', value: 'is_company'},
+  {name: 'type', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
+  {name: 'type', text: 'Make Company Order', type: 'button', value: 'is_company'},
   CANCEL_ORDER_ACTION,
 ]
 
 export const ORDER_URGENT_ACTIONS = [
-  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent-yes'},
-  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent-no'},
+  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent_yes'},
+  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent_no'},
   CANCEL_ORDER_ACTION,
 ]
 
-export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note-no'}
+export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note_no'}
 
 export const ORDER_NOTE_ACTIONS = [
-  {name: 'note', text: 'Add note', type: 'button', value: 'note-yes'},
+  {name: 'note', text: 'Add note', type: 'button', value: 'note_yes'},
   NOTE_NO_ACTION,
   CANCEL_ORDER_ACTION,
 ]

--- a/src/slack/vacuumlabs/constants.js
+++ b/src/slack/vacuumlabs/constants.js
@@ -117,21 +117,21 @@ export const ORDER_COMPANY_ACTIONS = [
 ]
 
 export const ORDER_TYPE_ACTIONS = [
-  {name: 'is_personal', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
-  {name: 'is_company', text: 'Make Company Order', type: 'button', value: 'is_company'},
+  {name: 'type', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
+  {name: 'type', text: 'Make Company Order', type: 'button', value: 'is_company'},
   CANCEL_ORDER_ACTION,
 ]
 
 export const ORDER_URGENT_ACTIONS = [
-  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent-yes'},
-  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent-no'},
+  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent_yes'},
+  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent_no'},
   CANCEL_ORDER_ACTION,
 ]
 
-export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note-no'}
+export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note_no'}
 
 export const ORDER_NOTE_ACTIONS = [
-  {name: 'note', text: 'Add note', type: 'button', value: 'note-yes'},
+  {name: 'note', text: 'Add note', type: 'button', value: 'note_yes'},
   NOTE_NO_ACTION,
   CANCEL_ORDER_ACTION,
 ]

--- a/src/slack/wincent/constants.js
+++ b/src/slack/wincent/constants.js
@@ -17,21 +17,21 @@ PS: Feel free to contribute at https://github.com/vacuumlabs/eshop-api`
 export const CANCEL_ORDER_ACTION = {name: 'cancel', text: 'Cancel Order', type: 'button', value: 'cancel', style: 'danger'}
 
 export const ORDER_TYPE_ACTIONS = [
-  {name: 'is_personal', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
-  {name: 'is_company', text: 'Make Company Order', type: 'button', value: 'is_company'},
+  {name: 'type', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
+  {name: 'type', text: 'Make Company Order', type: 'button', value: 'is_company'},
   CANCEL_ORDER_ACTION,
 ]
 
 export const ORDER_URGENT_ACTIONS = [
-  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent-yes'},
-  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent-no'},
+  {name: 'urgent', text: 'It\'s urgent, I will pay for delivery', type: 'button', value: 'urgent_yes'},
+  {name: 'urgent', text: 'It\'s not urgent, I can wait', type: 'button', value: 'urgent_no'},
   CANCEL_ORDER_ACTION,
 ]
 
-export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note-no'}
+export const NOTE_NO_ACTION = {name: 'note', text: 'Continue without note', type: 'button', value: 'note_no'}
 
 export const ORDER_NOTE_ACTIONS = [
-  {name: 'note', text: 'Add note', type: 'button', value: 'note-yes'},
+  {name: 'note', text: 'Add note', type: 'button', value: 'note_yes'},
   NOTE_NO_ACTION,
   CANCEL_ORDER_ACTION,
 ]


### PR DESCRIPTION
- added `ACTION_RANKS` for checking the order of actions.
- in each `order step` bot accceps first clicked among buttons and avoid next button clicks till next order step.
- mainly avoid some edge cases like: 
    1. multiple clicks on `Continue without note` buttion 
    2. click `Cancel` button after order subitted(stored in DB)

>  we can eliminate checks on all actions and remain only for no-note and canceling after order submission.

    