### PR TITLE
Refactor order updating and fix message handler branching

### DIFF
--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -324,7 +324,8 @@ export class Slack {
       this.orders[userId] = order
     }
 
-    if (order.messages === undefined) { // Initial message for entering item links
+    // messages are undefined initially, but it seems empty array is possible in some edge cases (possibly errors)
+    if (order.messages === undefined || order.messages.length === 0) {
       await this.updateOrder(message, userId, say)
     } else {
       // the `shift` here mutates the array - so always make sure the `messages` are copied, not directly assigned from `MESSAGES`

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -914,8 +914,7 @@ export class Slack {
       ].filter(Boolean),
     )
     try {
-      const {channel, ts} = await this.boltApp.client.chat.postMessage({
-        channel: userId,
+      const {channel, ts} = await say({
         attachments: [orderAttachment],
         text: ' ', // TODO: fix while migrate to use blocks
       })

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -855,7 +855,7 @@ export class Slack {
     }
   }
 
-  async updateOrder(order, message, user, say) {
+  async updateOrder(order, message, userId, say) {
     if (order.originalMessageInfo) {
       const {channel, ts} = order.originalMessageInfo
       try {
@@ -904,7 +904,7 @@ export class Slack {
     )
     try {
       const {channel, ts} = await this.boltApp.client.chat.postMessage({
-        channel: user,
+        channel: userId,
         attachments: [orderAttachment],
         text: ' ', // TODO: fix while migrate to use blocks
       })
@@ -913,7 +913,7 @@ export class Slack {
 
       return {...order, originalMessageInfo}
     } catch (err) {
-      logger.error(`Failed to post a message to user '${user}': ${err}`)
+      logger.error(`Failed to post a message to user '${userId}': ${err}`)
       throw err
     }
   }


### PR DESCRIPTION
I saw some more improvements when looking at near code, so I went to make the whole `order` passing more transparent. Now, all of the `updateOrder`, `submitOrder`, and `updateQuestion` functions take `userId` and retrieve `order` from `this.orders` themselves.