### PR TITLE
HAW23 - added new finish order step

### DIFF
--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -758,7 +758,9 @@ export class Slack {
       return
     }
 
-    if (order.step === 'finish' || order.step === 'reason') { // If order actions finished, update question
+    // TODO: not always we need to remove previous message
+    // - maybe we can remove this `updateQuestion` usage altogether and only use it when handling user's message
+    if (order.step === 'finish') {
       await this.updateQuestion(userId, say)
     } else {
       await this.updateMessage(respond, order)

--- a/src/slack/slack.js
+++ b/src/slack/slack.js
@@ -187,7 +187,7 @@ export class Slack {
           if (!order.user.name) order.user.name = this.orders[userId].user.name = username
 
           try {
-            this.handleUserAction(respond, action, userId, say)
+            await this.handleUserAction(respond, action, userId)
           } catch (err) {
             await say(':exclamation: Something went wrong, please try again.')
             await logError(this.boltApp, this.variant, err, 'User action error', userId, {
@@ -663,7 +663,7 @@ export class Slack {
     }
   }
 
-  async handleUserAction(respond, action, userId, say) {
+  async handleUserAction(respond, action, userId) {
     const order = this.orders[userId]
     const {name: actionName, value: actionValue} = action
 
@@ -758,13 +758,8 @@ export class Slack {
       return
     }
 
-    // TODO: not always we need to remove previous message
-    // - maybe we can remove this `updateQuestion` usage altogether and only use it when handling user's message
-    if (order.step === 'finish') {
-      await this.updateQuestion(userId, say)
-    } else {
-      await this.updateMessage(respond, order)
-    }
+    // update the order summary in place
+    await this.updateMessage(respond, order)
   }
 
   async notifyOfficeManager(order, dbId, user, isCompany) {

--- a/src/slack/test/constants.js
+++ b/src/slack/test/constants.js
@@ -136,6 +136,11 @@ export const ORDER_NOTE_ACTIONS = [
   CANCEL_ORDER_ACTION,
 ]
 
+export const ORDER_FINISH_ACTIONS = [
+  {name: 'finish', text: 'Finish Order', type: 'button', value: 'finish', style: 'primary'},
+  {name: 'cancel', text: 'Cancel Order', type: 'button', value: 'cancel', style: 'danger'},
+]
+
 export const USER_STEP_MAP = {
   country: {actions: ORDER_COUNTRY_ACTIONS, title: 'In which country is your office?'},
   delivery: {actions: DELIVERY_PLACE_ACTIONS, title: 'Where do you want to pickup the order?'},
@@ -144,4 +149,5 @@ export const USER_STEP_MAP = {
   company: {actions: ORDER_COMPANY_ACTIONS, title: 'Select your company:'},
   urgent: {actions: ORDER_URGENT_ACTIONS, title: 'How urgent is your order?'},
   note: {actions: ORDER_NOTE_ACTIONS, title: ':pencil: Do you want to add a note to the order?'},
+  finish: {actions: ORDER_FINISH_ACTIONS, title: ':grey_exclamation: Please review your order.'},
 }

--- a/src/slack/vacuumlabs/constants.js
+++ b/src/slack/vacuumlabs/constants.js
@@ -136,6 +136,11 @@ export const ORDER_NOTE_ACTIONS = [
   CANCEL_ORDER_ACTION,
 ]
 
+export const ORDER_FINISH_ACTIONS = [
+  {name: 'finish', text: 'Finish Order', type: 'button', value: 'finish', style: 'primary'},
+  {name: 'cancel', text: 'Cancel Order', type: 'button', value: 'cancel', style: 'danger'},
+]
+
 export const USER_STEP_MAP = {
   country: {actions: ORDER_COUNTRY_ACTIONS, title: 'In which country is your office?'},
   delivery: {actions: DELIVERY_PLACE_ACTIONS, title: 'Where do you want to pickup the order?'},
@@ -144,4 +149,5 @@ export const USER_STEP_MAP = {
   company: {actions: ORDER_COMPANY_ACTIONS, title: 'Select your company:'},
   urgent: {actions: ORDER_URGENT_ACTIONS, title: 'How urgent is your order?'},
   note: {actions: ORDER_NOTE_ACTIONS, title: ':pencil: Do you want to add a note to the order?'},
+  finish: {actions: ORDER_FINISH_ACTIONS, title: ':grey_exclamation: Please review your order.'},
 }

--- a/src/slack/wincent/constants.js
+++ b/src/slack/wincent/constants.js
@@ -36,8 +36,14 @@ export const ORDER_NOTE_ACTIONS = [
   CANCEL_ORDER_ACTION,
 ]
 
+export const ORDER_FINISH_ACTIONS = [
+  {name: 'finish', text: 'Finish Order', type: 'button', value: 'finish', style: 'primary'},
+  {name: 'cancel', text: 'Cancel Order', type: 'button', value: 'cancel', style: 'danger'},
+]
+
 export const USER_STEP_MAP = {
   type: {actions: ORDER_TYPE_ACTIONS},
   urgent: {actions: ORDER_URGENT_ACTIONS, title: 'How urgent is your order?'},
   note: {actions: ORDER_NOTE_ACTIONS, title: ':pencil: Do you want to add a note to the order?'},
+  finish: {actions: ORDER_FINISH_ACTIONS, title: ':grey_exclamation: Please review your order.'},
 }


### PR DESCRIPTION
- added new **Finish/Cancel Order** step
- Finish Order action handled by` updateQuestion()`
- removed msgTitle from userOrderAttachment. msgTitle destructed from order.messages on 'reason' and 'manager' steps.
- old '`finish`' step, became '`submit`'. 
   - initial_actions -> note/reason/manager -> finish -> submit