### PR TITLE
Disable personal orders for Vacuumlabs

### DIFF
--- a/src/slack/vacuumlabs/constants.js
+++ b/src/slack/vacuumlabs/constants.js
@@ -122,7 +122,6 @@ export const ORDER_COMPANY_ACTIONS = [
 ]
 
 export const ORDER_TYPE_ACTIONS = [
-  {name: 'type', text: 'Make Personal Order', type: 'button', value: 'is_personal'},
   {name: 'type', text: 'Make Company Order', type: 'button', value: 'is_company'},
   CANCEL_ORDER_ACTION,
 ]


### PR DESCRIPTION
I have left the same button for company orders and the flow as before. I believe it will keep the clarity of who will pay for the order and avoid some unnecessary questions for BackOffice